### PR TITLE
[DED-56] - Adjusting help text

### DIFF
--- a/cmd/cli/help_command.go
+++ b/cmd/cli/help_command.go
@@ -40,21 +40,21 @@ func (c HelpCommand) Main(ctx context.Context, pwd string, args []string) error 
 
 //general method prints the
 func (c HelpCommand) general() error {
-	fmt.Fprint(c.Stdout(), "Usage: depbot [command] [options]\n\n")
+	fmt.Fprint(c.Stdout(), "\nUsage:\n")
+	fmt.Fprint(c.Stdout(), "  depbot [command] [options]\n\n")
 
 	// If there are no commands it just prints the usage.
 	if len(c.Commands) == 0 {
 		return nil
 	}
 
-	fmt.Fprintln(c.Stdout(), "Available Commands:")
+	fmt.Fprint(c.Stdout(), "Available Commands:\n\n")
+	fmt.Fprint(c.Stdout(), "Command\n")
+
 	for _, v := range c.Commands {
 		if ht, ok := v.(HelpTexter); ok {
 			text := ht.HelpText()
-			if len(text) > 70 {
-				text = text[0:70] + "..."
-			}
-			fmt.Fprintf(c.Stdout(), "%v\t%v\n", v.Name(), text)
+			fmt.Fprintf(c.Stdout(), "  %v\t\t%v\n", v.Name(), text)
 			continue
 		}
 
@@ -62,7 +62,7 @@ func (c HelpCommand) general() error {
 	}
 
 	fmt.Fprintln(c.Stdout(), "\nFor command specific information use the help command, p.e.")
-	fmt.Fprintln(c.Stdout(), "$ depbot help [command]")
+	fmt.Fprint(c.Stdout(), "$ depbot help [command]\n\n")
 
 	return nil
 }

--- a/cmd/cli/help_command_test.go
+++ b/cmd/cli/help_command_test.go
@@ -27,8 +27,10 @@ func TestHelpCommand(t *testing.T) {
 			t.Fatalf("error running help: %v", err)
 		}
 
-		if !bytes.Contains(out.Bytes(), []byte("Usage: depbot [command] [options]")) {
-			t.Fatalf("expected output to contain 'Usage: depbot [command] [options]'")
+		fmt.Println("---> ", out.String())
+
+		if !bytes.Contains(out.Bytes(), []byte("depbot [command] [options]")) {
+			t.Fatalf("expected output to contain 'depbot [command] [options]'")
 		}
 
 		for _, v := range hc.Commands {
@@ -51,8 +53,8 @@ func TestHelpCommand(t *testing.T) {
 			t.Fatalf("Expected to print \"Error: did not find `unexisting` command\"")
 		}
 
-		if !bytes.Contains(out.Bytes(), []byte("Usage: depbot [command] [options]")) {
-			t.Fatalf("expected output to contain 'Usage: depbot [command] [options]'")
+		if !bytes.Contains(out.Bytes(), []byte("depbot [command] [options]")) {
+			t.Fatalf("expected output to contain 'depbot [command] [options]'")
 		}
 	})
 

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -48,7 +48,7 @@ func (c *Command) Name() string {
 }
 
 func (c *Command) HelpText() string {
-	return "Synchronizes the dependencies with the server. The server can be configured with the \nDEPBOT_SERVER_ADDR environment variable. It requires a repo API key. See flags for more info."
+	return "Synchronizes the dependencies with the server. The server can be configured with the \n\t\tDEPBOT_SERVER_ADDR environment variable. It requires a repo API key. See flags for more info."
 }
 
 func (c *Command) SetClient(client *http.Client) {


### PR DESCRIPTION
Help text was not showing the entire description for the commands.

![image](https://user-images.githubusercontent.com/25638999/173089843-8a9d648e-abb1-4199-8f29-2adcfce901f5.png)
