### PR TITLE
[DEP-12] - Server Address Env Variable

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -142,7 +142,7 @@ func NewCommand(finders ...depbot.FinderFn) *Command {
 	// its not set.
 	serverAddress := os.Getenv(DepbotServerAddr)
 	if serverAddress == "" {
-		serverAddress = "http://app.depbot.com/api/sync"
+		serverAddress = "https://app.depbot.com/api/sync"
 	}
 
 	return &Command{

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -67,9 +67,11 @@ func (c *Command) ParseFlags(args []string) (*flag.FlagSet, error) {
 		c.apiKey = os.Getenv(DepbotApiKey)
 	}
 
-	// Applying env if passed value was empty
-	if c.serverAddress == defaultServerAddress {
-		c.serverAddress = os.Getenv(DepbotServerAddr)
+	// Applying env if passed value was empty.
+	// IMPORTANT: We acknowledge that the server address flag will be
+	// overridden by the env variable if it is set to be the default.
+	if es := os.Getenv(DepbotServerAddr); c.serverAddress == defaultServerAddress && es != "" {
+		c.serverAddress = es
 	}
 
 	return c.flagSet, nil

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -57,6 +57,7 @@ func (c *Command) SetClient(client *http.Client) {
 
 func (c *Command) ParseFlags(args []string) (*flag.FlagSet, error) {
 	beforeApiKey := c.apiKey
+	beforeServerAddress := c.serverAddress
 
 	flagSet := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 
@@ -72,6 +73,10 @@ func (c *Command) ParseFlags(args []string) (*flag.FlagSet, error) {
 
 	if c.apiKey == "" {
 		c.apiKey = beforeApiKey
+	}
+
+	if c.serverAddress == "" {
+		c.serverAddress = beforeServerAddress
 	}
 
 	return flagSet, nil

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -137,7 +137,6 @@ func (c *Command) SetIO(stderr io.Writer, stdout io.Writer, stdin io.Reader) {
 
 // NewCommand with the given finder function.
 func NewCommand(finders ...depbot.FinderFn) *Command {
-
 	// Setting default value for the server address in case
 	// its not set.
 	serverAddress := os.Getenv(DepbotServerAddr)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -19,6 +19,9 @@ import (
 const (
 	DepbotApiKey     = "DEPBOT_API_KEY"
 	DepbotServerAddr = "DEPBOT_SERVER_ADDR"
+
+	// The default server address, could be changed with flags/env
+	defaultServerAddress = "https://app.depbot.com/api/sync"
 )
 
 var (
@@ -64,8 +67,8 @@ func (c *Command) ParseFlags(args []string) (*flag.FlagSet, error) {
 		c.apiKey = os.Getenv(DepbotApiKey)
 	}
 
-	// Applying env if apiKey is empty
-	if c.serverAddress == "" {
+	// Applying env if passed value was empty
+	if c.serverAddress == defaultServerAddress {
 		c.serverAddress = os.Getenv(DepbotServerAddr)
 	}
 
@@ -148,7 +151,7 @@ func NewCommand(finders ...depbot.FinderFn) *Command {
 	// Initializing the FlagSet that will pull the api-key and the server-address
 	fls := flag.NewFlagSet(c.Name(), flag.ContinueOnError)
 	fls.StringVar(&c.apiKey, "api-key", "", "[required] The API key for the repo. Can be specified with the DEPBOT_API_KEY environment variable.")
-	fls.StringVar(&c.serverAddress, "server-address", "https://app.depbot.com/api/sync", "The server address. Can be specified with the DEPBOT_SERVER_ADDR environment variable.")
+	fls.StringVar(&c.serverAddress, "server-address", defaultServerAddress, "The server address. Can be specified with the DEPBOT_SERVER_ADDR environment variable.")
 	fls.SetOutput(bytes.NewBuffer([]byte{}))
 	fls.Usage = func() {}
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -215,5 +215,4 @@ func TestSyncCommand(t *testing.T) {
 			t.Errorf("expected output to contain '%v'", "FLAG")
 		}
 	})
-
 }


### PR DESCRIPTION
This PR changes the way we handle different values between the environment variable and the flag for the server address and the default value. While on it moved the initialization of the flagset to the NewCommand builder, so we have that set within the command just to be used.