### PR TITLE
sending commit value instead of static value when getting branch name

### DIFF
--- a/internal/revision/revision.go
+++ b/internal/revision/revision.go
@@ -44,7 +44,7 @@ func FindBranchName(pwd string) (string, error) {
 
 	/// HEAD points to a commit in particular.
 	if len(headData) > 0 {
-		return "checked commit", nil
+		return headData, nil
 	}
 
 	return "", fmt.Errorf("oops! No branch name available")


### PR DESCRIPTION
* sending commit as a branch name when checked out to a particular commit 
e.g. "d77019f6c0a3908030864cf7b5c942004b8873f5", the branch name would be a fixed string "checked commit" instead the same commit.